### PR TITLE
basic 06_backtracking 문제 해결

### DIFF
--- a/week2/basic/06_backtracking.py
+++ b/week2/basic/06_backtracking.py
@@ -45,14 +45,20 @@ def combinations(n, k):
         """
         # TODO: base case - k개를 모두 선택했으면 결과에 추가
         pass
+        if len(current_combination) == k:
+            result.append(current_combination[:])  # 현재 조합을 결과에 추가
+            return
         
         # TODO: start부터 n까지 숫자를 하나씩 시도
         ## TODO: 백트랙킹 3단계 구현
         ## 1. 선택(Choose)
+        for i in range(start, n+1):
+            current_combination.append(i)
+            backtrack(i+1, current_combination)
+            current_combination.pop()
         ## 2. 탐색(Explore)
         ## 3. 취소(Unchoose)
-        pass
-    
+
     backtrack(1, [])
     return result
 


### PR DESCRIPTION
백트래킹 문제의 '핵심'은
재귀함수와 for문이다.

기본적으로는 재귀함수로서 backtrack 본인을 불러오는데, 이때 종료 조건이 깊이일 가능성이 높다.

그러고나면 for문을 돌아야한다.
for문을 도는 이유는 깊이우선탐색과 비슷하다고 생각할 수 있다.
값을 하나씩 추가했다가 하나씩 빼야하므로 for문으로 돌며 값을 넣고 뺀다.

이때, 더 작은 값을 다시 선택하는 일이 없도록 더 뒤에 있는 값을 선택하도록 for문을 설정해야 한다.