### PR TITLE
basic 10_number_theory 문제 해결

### DIFF
--- a/week2/basic/10_number_theory.py
+++ b/week2/basic/10_number_theory.py
@@ -24,6 +24,8 @@
 - LCM 공식: lcm(a, b) = (a × b) / gcd(a, b)
 """
 
+import math
+
 def gcd(a, b):
     """
     유클리드 호제법을 사용한 최대공약수 계산
@@ -36,8 +38,18 @@ def gcd(a, b):
     """
     # TODO: 유클리드 호제법 구현
     # base case: b가 0이면 a 반환
-    # recursive를 이용 
-    pass
+    # recursive를 이용
+    if b == 0:
+        return a
+    return gcd(b, a%b)
+
+# def gcd(a, b):
+#     if b == 0:
+#         return a
+#     else:
+#         return gcd(b, a%b)
+
+# print(gcd(4212, 2484))
 
 def gcd_iterative(a, b):
     """
@@ -51,6 +63,13 @@ def gcd_iterative(a, b):
     """
     # TODO: 반복문으로 구현
     # b가 0이 될 때까지 반복
+    while True:
+        if a % b == 0:
+            return b
+        
+        temp = a
+        a = b
+        b = temp % a
     pass
 
 def lcm(a, b):
@@ -64,6 +83,9 @@ def lcm(a, b):
         최소공배수
     """
     # TODO: LCM 계산
+    target = a*b
+    what = gcd(a, b)
+    return target // what
     pass
 
 def extended_gcd(a, b):
@@ -78,9 +100,17 @@ def extended_gcd(a, b):
         (gcd, x, y) 튜플
     """
     # TODO: 확장 유클리드 호제법 구현
-    # base case: b가 0이면 (a, 1, 0) 반환    
+    if (b == 0):
+        return (a, 1, 0)
+    # base case: b가 0이면 (a, 1, 0) 반환
     # recursive case
+    gcd, x1, y1 = extended_gcd(b, a%b)
     # 역추적하며 x, y 계산
+    x = y1
+    y = x1 - (a // b) * y1
+
+    return gcd, x, y
+
     pass
 
 def is_prime(n):
@@ -95,7 +125,19 @@ def is_prime(n):
     """
     # TODO: 소수 판별 구현
     # n이 2보다 작으면 False
-    # 2부터 sqrt(n)까지 나누어 떨어지는지 확인    
+    if (n < 2):
+        return False
+    if (n == 2):
+        return True
+    # 2부터 sqrt(n)까지 나누어 떨어지는지 확인
+    if (n % 2 == 0):
+        return False
+
+    for i in range(3, int(math.sqrt(n))+1, 2):
+        if n % i == 0:
+            return False
+
+    return True
     # 3부터 sqrt(n)까지 홀수만 확인
     pass 
 


### PR DESCRIPTION
유클리드 호제법 : 최대 공약수를 얻기 위한 재귀함수
gcd(a,b) 일 때, b가 0이 아니라면, gcd(b, a mod b)를 실행하여 또 b가 0인지 확인하는 재귀.

반복문은 while로 구현이 가능함

LCM 최소공배수는 / 연산자를 쓰면 실수가 되어서 출력 오류가 나오니 조심해야함

extended_gcd 확장된 유클리드 호제법은 우선 gcd를 끝까지 내려갔다가 
return 값에 gcd, x1, y1의 값을 주어 올라오면서 역추적하여 답을 구한다.
x = y1, y = x1 - (a // b) * y1을 주는데, 이유는 ax + by = bx + (a mod b)y 이기 때문이다.
이렇게 적어놓으니 이상한데, 값만 다른거지 결국 같은 결과여야 하기 때문이다.
a mod b = a - (a//b) * b를 통해서 나머지를 구할 수 있으므로 a  mod b 대신에 a - (a//b) * b 를 대입하여 풀면 위와같이 나온다.

소수 문제는
sqrt()를 생각하고 풀었다. 근데 생각해보니 i*i < n 이라는 조건이 있어서 그걸로도 풀 수 있다.